### PR TITLE
feature/cache-control-max-age

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ node {
     }
 
     stage('Bundle') {
-        sh "aws s3 sync --delete --acl public-read assets s3://${env.S3_CDN_BUCKET}/assets/"
+        sh "aws s3 sync --delete --acl public-read --cache-control max-age=1209600 assets s3://${env.S3_CDN_BUCKET}/assets/"
     }
 }


### PR DESCRIPTION
Set `Cache-Control: max-age` header for asset objects. This is initially set to `1209600` seconds (2 weeks).