### PR TITLE
Cloudflare error pages require a token which has now been added

### DIFF
--- a/assets/html/error-pages/service-error.html
+++ b/assets/html/error-pages/service-error.html
@@ -109,6 +109,7 @@
             </div>
         </div>
     </div>
+    <div class="hidden">::CLOUDFLARE_ERROR_500S_BOX::</div>
     <div id="viewport-sm" class="js-viewport-size"></div>
     <div id="viewport-md" class="js-viewport-size"></div>
     <div id="viewport-lg" class="js-viewport-size"></div>


### PR DESCRIPTION
### What
- Custom error pages require a Cloudflare token which has now been added for 5XX errors
Information can be found here: https://support.cloudflare.com/hc/en-us/articles/200172706-Customizing-Cloudflare-error-pages

### How to review
- Ensure that the token is on the DOM, note that it is a hidden element

### Who can review 
- Anyone except me
