### PR TITLE
Add support for Cloudflare 1000 and Always Online errors

### DIFF
--- a/assets/html/error-pages/service-error.html
+++ b/assets/html/error-pages/service-error.html
@@ -110,6 +110,8 @@
         </div>
     </div>
     <div class="hidden">::CLOUDFLARE_ERROR_500S_BOX::</div>
+    <div class="hidden">::CLOUDFLARE_ERROR_1000S_BOX::</div>
+    <div class="hidden">::ALWAYS_ONLINE_NO_COPY_BOX::</div>
     <div id="viewport-sm" class="js-viewport-size"></div>
     <div id="viewport-md" class="js-viewport-size"></div>
     <div id="viewport-lg" class="js-viewport-size"></div>


### PR DESCRIPTION
Extend the error page template to handle additional Cloudflare errors
for 1000 status codes and for when Always Online does not have a cached
version of the page.