### PR TITLE
Revert error page for todays releases - put it back to standard error page

### DIFF
--- a/assets/html/error-pages/service-error.html
+++ b/assets/html/error-pages/service-error.html
@@ -62,19 +62,13 @@
                         <div class="ons-grid ons-u-ml-no">
                             <div class="ons-grid__col ons-u-pl-no">
                                 <h1 class="ons-u-mt-xl ons-u-fw-b">
-                                    There are currently a high number of requests for the ONS website.
+                                    Sorry, there's a problem with the service
                                 </h1>
                                 <div class="ons-page__main ons-u-mt-s">
                                     <p>Try again later.</p>
-                                    <p>In the meantime, you can download PDF versions of the latest GDP bulletin:</p>
-                                    <p><a href="https://static.ons.gov.uk/timeseries-datasets/bulletins/2024-05-10/GDP-first-quarterly-estimate-UK-January-to-March-2024.pdf?id=2F6C400D-A3A0-4B11-9866-62B56CEE1EF6">GDP first quarterly estimate, UK: January to March 2024</a> (PDF, 1,153 KB)</p>
                                     <p>
-                                        You can also find previous scheduled publications on our
-                                        <a href="https://backup.ons.gov.uk/">backup site</a> or check our <a
-                                            href="https://twitter.com/ONS"
-                                            class="icon--hide"
-                                            target="_blank"
-                                        >X (Twitter) feed</a> for updates.
+                                        Our scheduled publications can also be found on our
+                                        <a href="https://backup.ons.gov.uk/">backup site</a>.
                                     </p>
                                     <p>If you have any questions,
                                         <a


### PR DESCRIPTION
- Replaced message about high number of requests with the standard error message.
- Removed message about latest GDP bulletin and link to pdf. 
